### PR TITLE
build: fix path-to-regexp to older version due to node 14 requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "pack-n-play": "^2.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^18.0.0",
+    "nise": "6.0.0",
+    "path-to-regexp": "6.2.2",
     "tmp": "^0.2.0",
     "typescript": "^5.1.6",
     "yargs": "^17.3.1"


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #2138
