### PR TITLE
fix: Implement path containment to prevent traversal attacks

### DIFF
--- a/samples/system-test/transfer-manager.test.js
+++ b/samples/system-test/transfer-manager.test.js
@@ -56,26 +56,37 @@ describe('transfer manager', () => {
     );
   });
 
-  it('should download mulitple files', async () => {
+  it('should download multiple files', async () => {
+    // Remove absolute path marker to prepare for joining/validation.
+    const expectedFirstFilePath = firstFilePath.startsWith('/')
+      ? firstFilePath.slice(1)
+      : firstFilePath;
+    const expectedSecondFilePath = secondFilePath.startsWith('/')
+      ? secondFilePath.slice(1)
+      : secondFilePath;
     const output = execSync(
-      `node downloadManyFilesWithTransferManager.js ${bucketName} ${firstFilePath} ${secondFilePath}`
+      `node downloadManyFilesWithTransferManager.js ${bucketName} ${expectedFirstFilePath} ${expectedSecondFilePath}`
     );
     assert.match(
       output,
       new RegExp(
-        `gs://${bucketName}/${firstFilePath} downloaded to ${firstFilePath}.\ngs://${bucketName}/${secondFilePath} downloaded to ${secondFilePath}.`
+        `gs://${bucketName}/${expectedFirstFilePath} downloaded to ${expectedFirstFilePath}.\ngs://${bucketName}/${expectedSecondFilePath} downloaded to ${expectedSecondFilePath}.`
       )
     );
   });
 
   it('should download a file utilizing chunked download', async () => {
+    // Remove absolute path marker to prepare for joining/validation.
+    const expectedFirstFilePath = firstFilePath.startsWith('/')
+      ? firstFilePath.slice(1)
+      : firstFilePath;
     const output = execSync(
-      `node downloadFileInChunksWithTransferManager.js ${bucketName} ${firstFilePath} ${downloadFilePath} ${chunkSize}`
+      `node downloadFileInChunksWithTransferManager.js ${bucketName} ${expectedFirstFilePath} ${downloadFilePath} ${chunkSize}`
     );
     assert.match(
       output,
       new RegExp(
-        `gs://${bucketName}/${firstFilePath} downloaded to ${downloadFilePath}.`
+        `gs://${bucketName}/${expectedFirstFilePath} downloaded to ${downloadFilePath}.`
       )
     );
   });

--- a/src/file.ts
+++ b/src/file.ts
@@ -545,6 +545,8 @@ export enum FileExceptionMessages {
     To be sure the content is the same, you should try uploading the file again.`,
   MD5_RESUMED_UPLOAD = 'MD5 cannot be used with a continued resumable upload as MD5 cannot be extended from an existing value',
   MISSING_RESUME_CRC32C_FINAL_UPLOAD = 'The CRC32C is missing for the final portion of a resumed upload, which is required for validation. Please provide `resumeCRC32C` if validation is required, or disable `validation`.',
+  ABSOLUTE_FILE_NAME = 'Object name is an absolute path. Security block to prevent arbitrary file writes.',
+  TRAVERSAL_OUTSIDE_BASE = 'Path traversal detected. Security block to prevent writing outside the base directory.',
 }
 
 /**

--- a/src/file.ts
+++ b/src/file.ts
@@ -547,6 +547,7 @@ export enum FileExceptionMessages {
   MISSING_RESUME_CRC32C_FINAL_UPLOAD = 'The CRC32C is missing for the final portion of a resumed upload, which is required for validation. Please provide `resumeCRC32C` if validation is required, or disable `validation`.',
   ABSOLUTE_FILE_NAME = 'Object name is an absolute path. Security block to prevent arbitrary file writes.',
   TRAVERSAL_OUTSIDE_BASE = 'Path traversal detected. Security block to prevent writing outside the base directory.',
+  TRAVERSAL_OUTSIDE_BASE_DESTINATION = "The provided destination path is unsafe and attempts to traverse outside the application's base directory (current working directory).",
 }
 
 /**

--- a/src/transfer-manager.ts
+++ b/src/transfer-manager.ts
@@ -629,10 +629,7 @@ export class TransferManager {
         throw traversalError;
       }
 
-      const isDirectoryMarker =
-        file.name.endsWith('/') || file.name.endsWith(path.sep);
-
-      if (isDirectoryMarker && !finalPath.endsWith(path.sep)) {
+      if (file.name.endsWith('/') && !finalPath.endsWith(path.sep)) {
         finalPath = finalPath + path.sep;
       }
 

--- a/src/transfer-manager.ts
+++ b/src/transfer-manager.ts
@@ -620,7 +620,8 @@ export class TransferManager {
 
       // Resolve the final path and perform the containment check
       let finalPath = path.resolve(baseDir, name);
-      if (!finalPath.startsWith(baseDir + path.sep) && finalPath !== baseDir) {
+      const relative = path.relative(baseDir, finalPath);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
         const traversalError = new RequestError(
           FileExceptionMessages.TRAVERSAL_OUTSIDE_BASE
         );

--- a/src/transfer-manager.ts
+++ b/src/transfer-manager.ts
@@ -592,9 +592,20 @@ export class TransferManager {
       : EMPTY_REGEX;
     const regex = new RegExp(stripRegexString, 'g');
 
+    const cwd = process.cwd();
     const baseDir = path.resolve(
-      options.passthroughOptions?.destination ?? process.cwd()
+      options.passthroughOptions?.destination ?? cwd
     );
+
+    const relativeBaseDir = path.relative(cwd, baseDir);
+
+    if (relativeBaseDir.startsWith('..') || path.isAbsolute(relativeBaseDir)) {
+      const traversalError = new RequestError(
+        FileExceptionMessages.TRAVERSAL_OUTSIDE_BASE_DESTINATION
+      );
+      traversalError.code = 'SECURITY_PATH_TRAVERSAL_REJECTED';
+      throw traversalError;
+    }
 
     for (const file of files) {
       let name = file.name;

--- a/src/transfer-manager.ts
+++ b/src/transfer-manager.ts
@@ -620,7 +620,6 @@ export class TransferManager {
         const absolutePathError = new RequestError(
           FileExceptionMessages.ABSOLUTE_FILE_NAME
         );
-        absolutePathError.code = 'SECURITY_ABSOLUTE_PATH_REJECTED';
         throw absolutePathError;
       }
 
@@ -633,7 +632,6 @@ export class TransferManager {
         const traversalError = new RequestError(
           FileExceptionMessages.TRAVERSAL_OUTSIDE_BASE
         );
-        traversalError.code = 'SECURITY_PATH_TRAVERSAL_REJECTED';
         throw traversalError;
       }
 
@@ -939,7 +937,6 @@ export class TransferManager {
       const traversalError = new RequestError(
         FileExceptionMessages.TRAVERSAL_OUTSIDE_BASE_DESTINATION
       );
-      traversalError.code = 'SECURITY_PATH_TRAVERSAL_REJECTED';
       throw traversalError;
     }
 

--- a/src/transfer-manager.ts
+++ b/src/transfer-manager.ts
@@ -594,7 +594,7 @@ export class TransferManager {
       });
     }
 
-    const baseDir = this._getValidatedBaseDirectory(options);
+    const baseDir = this._resolveAndValidateBaseDir(options);
 
     const stripRegexString = options.stripPrefix
       ? `^${options.stripPrefix}`
@@ -921,7 +921,7 @@ export class TransferManager {
    * @param options The download options, potentially containing passthroughOptions.destination.
    * @returns The absolute, validated base directory path (baseDir).
    */
-  private _getValidatedBaseDirectory(
+  private _resolveAndValidateBaseDir(
     options: DownloadManyFilesOptions
   ): string {
     const cwd = process.cwd();

--- a/test/transfer-manager.ts
+++ b/test/transfer-manager.ts
@@ -403,7 +403,7 @@ describe('Transfer Manager', () => {
         prefix: prefix,
       });
       assert.strictEqual(
-        mkdirSpy.calledOnceWith(expectedDir, {
+        mkdirSpy.calledWith(expectedDir, {
           recursive: true,
         }),
         true

--- a/test/transfer-manager.ts
+++ b/test/transfer-manager.ts
@@ -289,20 +289,37 @@ describe('Transfer Manager', () => {
       const maliciousFilename = '/etc/passwd';
       const file = new File(bucket, maliciousFilename);
 
-      await assert.rejects(() => transferManager.downloadManyFiles([file]), {
+      await assert.rejects(transferManager.downloadManyFiles([file]), {
         code: 'SECURITY_ABSOLUTE_PATH_REJECTED',
       });
     });
 
-    it('should throws an error for path traversal in destination or file name', async () => {
+    it('should throw an error for path traversal in destination', async () => {
       const passthroughOptions = {
-        destination: '../../test-destination',
+        destination: '../traversal-destination',
       };
-      const filename = '../../first.txt';
-
-      const file = new File(bucket, filename);
+      const file = new File(bucket, 'first.txt');
       await assert.rejects(
         transferManager.downloadManyFiles([file], {passthroughOptions}),
+        {
+          code: 'SECURITY_PATH_TRAVERSAL_REJECTED',
+        }
+      );
+    });
+
+    it('should throw an error for path traversal in file name', async () => {
+      const file = new File(bucket, '../traversal-filename.txt');
+      await assert.rejects(transferManager.downloadManyFiles([file]), {
+        code: 'SECURITY_PATH_TRAVERSAL_REJECTED',
+      });
+    });
+
+    it('should throw an error for path traversal using prefix', async () => {
+      const file = new File(bucket, 'first.txt');
+      await assert.rejects(
+        transferManager.downloadManyFiles([file], {
+          prefix: '../traversal-prefix',
+        }),
         {
           code: 'SECURITY_PATH_TRAVERSAL_REJECTED',
         }

--- a/test/transfer-manager.ts
+++ b/test/transfer-manager.ts
@@ -218,7 +218,10 @@ describe('Transfer Manager', () => {
     it('sets the destination correctly when provided a prefix', async () => {
       const prefix = 'test-prefix';
       const filename = 'first.txt';
-      const expectedDestination = path.normalize(`${prefix}/${filename}`);
+      const expectedDestination = path.resolve(
+        process.cwd(),
+        path.join(prefix, filename)
+      );
 
       const file = new File(bucket, filename);
       sandbox.stub(file, 'download').callsFake(options => {
@@ -233,7 +236,7 @@ describe('Transfer Manager', () => {
     it('sets the destination correctly when provided a strip prefix', async () => {
       const stripPrefix = 'should-be-removed/';
       const filename = 'should-be-removed/first.txt';
-      const expectedDestination = 'first.txt';
+      const expectedDestination = path.resolve(process.cwd(), 'first.txt');
 
       const file = new File(bucket, filename);
       sandbox.stub(file, 'download').callsFake(options => {
@@ -263,8 +266,10 @@ describe('Transfer Manager', () => {
         destination: 'test-destination',
       };
       const filename = 'first.txt';
-      const expectedDestination = path.normalize(
-        `${passthroughOptions.destination}/${filename}`
+      const expectedDestination = path.resolve(
+        process.cwd(),
+        passthroughOptions.destination,
+        filename
       );
       const download = (optionsOrCb?: DownloadOptions | DownloadCallback) => {
         if (typeof optionsOrCb === 'function') {
@@ -278,6 +283,30 @@ describe('Transfer Manager', () => {
       const file = new File(bucket, filename);
       file.download = download;
       await transferManager.downloadManyFiles([file], {passthroughOptions});
+    });
+
+    it('should throws an error for absolute file names', async () => {
+      const maliciousFilename = '/etc/passwd';
+      const file = new File(bucket, maliciousFilename);
+
+      await assert.rejects(() => transferManager.downloadManyFiles([file]), {
+        code: 'SECURITY_ABSOLUTE_PATH_REJECTED',
+      });
+    });
+
+    it('should throws an error for path traversal in destination or file name', async () => {
+      const passthroughOptions = {
+        destination: '../../test-destination',
+      };
+      const filename = '../../first.txt';
+
+      const file = new File(bucket, filename);
+      await assert.rejects(
+        transferManager.downloadManyFiles([file], {passthroughOptions}),
+        {
+          code: 'SECURITY_PATH_TRAVERSAL_REJECTED',
+        }
+      );
     });
 
     it('does not download files that already exist locally when skipIfExists is true', async () => {
@@ -301,14 +330,16 @@ describe('Transfer Manager', () => {
       await transferManager.downloadManyFiles(files, options);
     });
 
-    it('does not set the destination when prefix, strip prefix and passthroughOptions.destination are not provided', async () => {
+    it('sets the destination to CWD when prefix, strip prefix and passthroughOptions.destination are not provided', async () => {
       const options = {};
       const filename = 'first.txt';
+      const expectedDestination = path.resolve(process.cwd(), filename);
+
       const download = (optionsOrCb?: DownloadOptions | DownloadCallback) => {
         if (typeof optionsOrCb === 'function') {
           optionsOrCb(null, Buffer.alloc(0));
         } else if (optionsOrCb) {
-          assert.strictEqual(optionsOrCb.destination, undefined);
+          assert.strictEqual(optionsOrCb.destination, expectedDestination);
         }
         return Promise.resolve([Buffer.alloc(0)]) as Promise<DownloadResponse>;
       };
@@ -321,10 +352,16 @@ describe('Transfer Manager', () => {
     it('should recursively create directory and write file contents if destination path is nested', async () => {
       const prefix = 'text-prefix';
       const folder = 'nestedFolder/';
-      const file = 'first.txt';
-      const filesOrFolder = [folder, path.join(folder, file)];
-      const expectedFilePath = path.join(prefix, folder, file);
-      const expectedDir = path.join(prefix, folder);
+      const filename = 'first.txt';
+      const filesOrFolder = [folder, path.join(folder, filename)];
+      const dirNameWithPrefix = path.join(prefix, folder);
+      const normalizedDir = path.resolve(process.cwd(), dirNameWithPrefix);
+      const expectedDir = normalizedDir + path.sep;
+      const expectedFilePath = path.resolve(
+        process.cwd(),
+        path.join(prefix, folder, filename)
+      );
+
       const mkdirSpy = sandbox.spy(fsp, 'mkdir');
       const download = (optionsOrCb?: DownloadOptions | DownloadCallback) => {
         if (typeof optionsOrCb === 'function') {
@@ -335,9 +372,14 @@ describe('Transfer Manager', () => {
         return Promise.resolve([Buffer.alloc(0)]) as Promise<DownloadResponse>;
       };
 
-      sandbox.stub(bucket, 'file').callsFake(filename => {
-        const file = new File(bucket, filename);
-        file.download = download;
+      sandbox.stub(bucket, 'file').callsFake(objectName => {
+        const file = new File(bucket, objectName);
+        if (objectName === path.join(folder, filename)) {
+          file.download = download;
+        } else {
+          file.download = () =>
+            Promise.resolve([Buffer.alloc(0)]) as Promise<DownloadResponse>;
+        }
         return file;
       });
       await transferManager.downloadManyFiles(filesOrFolder, {


### PR DESCRIPTION
## Description

>This PR addresses a potential **Arbitrary File Write / Path Traversal vulnerability** in `TransferManager.downloadManyFiles()` by enforcing strict path containment checks on all downloaded object names.
>
>The entire path assembly pipeline has been refactored to prioritize security and path normalization:
>
>
>1. **Sequential Name Assembly:** All path modifications (`stripPrefix`, `prefix`) are applied sequentially to the relative object name before security validation.
>
>2. **Absolute Path Rejection:** The function now immediately rejects object names (even after modification) that are absolute paths (e.g., `/etc/passwd`).
>
>3. **Canonical Resolution and Containment:** The final relative path is resolved into an absolute path (`finalPath = path.resolve(baseDir, name)`). The function then verifies that `finalPath` strictly begins with the absolute `baseDir`, preventing path traversal sequences like `../../`.
>
>4. **Directory Marker Fix:** A critical fix was added to explicitly check if the original GCS object name was a directory marker (ends in `/`). Since `path.resolve` strips the trailing slash, logic was added to re-add the separator to `finalPath` for directory markers, ensuring `fsp.mkdir` is called correctly.
>
>
>The old, manual, and insecure logic for joining `prefix` and `destination` using `path.join()` was removed as it bypassed these new security checks.

## Impact

> The primary impact is a significant **security uplift** for all users utilizing `downloadManyFiles()`.
>
>
>- **Security:** Prevents malicious object names from writing files outside the intended download folder (e.g., preventing overwrites of configuration files or system files).
>
>- **Behavioral Change**: If a malicious path traversal attempt is detected, the function will no longer silently fail or attempt an unsafe operation. It will now explicitly throw a `SECURITY_PATH_TRAVERSAL_REJECTED` error (or `SECURITY_ABSOLUTE_PATH_REJECTED`).
>
>- **Internal Consistency:** The destination passed to the underlying `file.download` method is now always a canonical, absolute path, improving consistency across all download scenarios.

## Testing

> **Yes, unit tests were heavily modified.**
>
>- All existing tests related to checking the destination path (`prefix`, `stripPrefix`, `passthroughOptions.destination`, and default download) were updated to assert against the new **absolute, canonical path** returned by the secure logic.
>
>- New test assertions were added to explicitly verify that attempts to use absolute paths or traversal sequences result in the expected security exceptions.
>
>- The complex test for nested directories was fully refactored and now passes, confirming that the new directory marker fix correctly triggers the recursive `fsp.mkdir` call.
>
>**Breaking Changes:** None technically, as the previous behavior was insecure. However, consumers who rely on supplying relative paths for `passthroughOptions.destination` will now receive absolute paths in the underlying `file.download` callback options, which is a desirable side effect of the security fix.

## Additional Information

> The implementation detail to note is the use of `path.resolve` for path canonicalization. This forced the manual re-insertion of the trailing path separator (`path.sep`) for GCS folder markers, as `path.resolve` strips it, which otherwise would prevent the directory from being created recursively. This refactoring was essential to maintaining directory creation functionality while enforcing path safety.

## Checklist

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/nodejs-storage/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease
- [ ] Appropriate docs were updated
- [ ] Appropriate comments were added, particularly in complex areas or places that require background
- [ ] No new warnings or issues will be generated from this change

Fixes #issue_number_goes_here 🦕
